### PR TITLE
Get date_time from file structure if METADATA is missing and emit a warning

### DIFF
--- a/R/experiment-info.R
+++ b/R/experiment-info.R
@@ -16,9 +16,18 @@ experiment_info <- function(FILE){
     {metadata <- RSQLite::dbGetQuery(con, "SELECT * FROM METADATA")},
     finally={RSQLite::dbDisconnect(con)})
 
-  v <- as.list(metadata$value)
-  names(v) <- metadata$field
-  #fixme explicitly GMT
-  v$date_time <- as.POSIXct(as.integer(v$date_time),origin="1970-01-01",tz = "GMT")
+  if (nrow(metadata) == 0) {
+    warning(paste0("sqlite3 file ", FILE, "has an empty METADATA table"))
+    v <- list()
+    # this assumes the folder the dbfile lives in is the datetime when the experiment started, which should be true in a normal case
+    # the format of the datetime is YYYY-MM-DD_HH-MM-SS
+    date_time_str <- rev(unlist(strsplit(dirname(FILE), split ="/")))[1]
+    v$date_time <- as.POSIXct(date_time_str, tz="GMT", format="%Y-%m-%d_%H-%M-%S")
+  } else {
+    v <- as.list(metadata$value)
+    names(v) <- metadata$field
+    #fixme explicitly GMT
+    v$date_time <- as.POSIXct(as.integer(v$date_time),origin="1970-01-01",tz = "GMT")
+  }
   return(v)
 }


### PR DESCRIPTION
This is useful to avoid the following error upon calling `load_ethoscope`
```
Error in `[.data.table`(roi_dt, , `:=`(t, (t + ms_after_ref)/1000)) : 
  RHS of assignment to existing column 't' is zero length but not NULL. If you intend to delete the column use NULL. Otherwise, the RHS must have length > 0; e.g., NA_integer_. If you are trying to change the column type to be an empty list column then, as with all column type changes, provide a full length RHS vector such as vector('list',nrow(DT)); i.e., 'plonk' in the new column.
```

The error occurs because ms_after_ref is a vector of length 0 because it is derived from experiment_info$date_time, which is NULL or at least not Truthy (length 0, etc) when the METADATA table is empty. The fix is to get the date_time of the dbfile from the filename or the folder itself. However, all dbfiles should have a METADATA for documentation purposes.